### PR TITLE
Clean up in static vs shared packaging + licenses + cmake...

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -179,6 +179,12 @@ class MathglConan(ConanFile):
                 for file in files:
                     if redll.match(file):
                         os.remove(os.path.join(root,file))
+        if self.settings.os == "Windows":
+            tools.rmdir(os.path.join(self.package_folder,'cmake'))
+            if os.path.exists(os.path.join(self.package_folder, 'mathgl2-config.cmake')):
+                os.remove(os.path.join(self.package_folder, 'mathgl2-config.cmake'))
+        else:
+            tools.rmdir(os.path.join(self.package_folder,'lib','cmake'))
         self.copy('COPYING', dst="licenses", src=self.source_subfolder,
                   ignore_case=True, keep_path=False)
         if self.options.lgpl:

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,7 +77,6 @@ class MathglConan(ConanFile):
             self.cmake_options["enable-{}".format(val)] = 'OFF'
 
     def requirements(self):
-
         self.add_cmake_opt("lgpl", self.options.lgpl)
         self.add_cmake_opt("double", self.options.double_precision)
         self.add_cmake_opt("rvalue", self.options.rvalue_support)
@@ -100,7 +99,7 @@ class MathglConan(ConanFile):
             self.add_cmake_opt("gsl", self.options.gsl)
             self.add_cmake_opt("hdf5", self.options.hdf5)
             self.add_cmake_opt("all-swig", self.options.all_swig)
-
+        
         # TODO add dependencies using conan packages
         # expected to be found w/o conan: glut, fltk, ltdl, gsl, mpi
 
@@ -113,12 +112,13 @@ class MathglConan(ConanFile):
             self.requires("libpng/[>=1.6.34]")
         if self.options.jpeg:
             self.requires("libjpeg-turbo/[>=1.5.2 <2.0]@bincrafters/stable",
-                          private=True)
+                          private=self.options.shared)
             # set jpeg version 62
         if self.options.gif:
             self.requires("giflib/[>=5.1.4]@bincrafters/stable")
         if self.options.pdf:
-            self.requires("libharu/[>=2.3.0]@sintef/stable", private=True)
+            self.requires("libharu/[>=2.3.0]@sintef/stable",
+                          private=self.options.shared)
             self.options["libharu"].shared = False
         if self.options.hdf5:
             if not self.options.lgpl:
@@ -136,10 +136,8 @@ class MathglConan(ConanFile):
                     "pthr_widget, pthread are incompatible with Visual Studio")
 
     def source(self):
-
         link = "https://sourceforge.net/projects/mathgl/files/mathgl/mathgl%20{0}/mathgl-{0}.tar.gz".format(self.version)
         tools.get(link, sha1="c7faa770a78a8b6783a4eab6959703172f28b329")  # sha1 is for 2.4.4
-
         tools.patch(patch_file="patch/CMakeLists.patch",
                     base_path=self.source_subfolder)
 
@@ -176,7 +174,8 @@ class MathglConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.name = 'MathGL'
-        self.cpp_info.builddirs.append("cmake")
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.builddirs.append("cmake")
         self.cpp_info.libs = ["mgl"]
         if self.options.qt5:
             self.cpp_info.libs.append('mgl-qt5')
@@ -184,7 +183,9 @@ class MathglConan(ConanFile):
         if self.options.wxWidgets:
             self.cpp_info.libs.append('mgl-wx')
 
-        if not self.options.shared and self.settings.compiler == "Visual Studio":
+        #if not self.options.shared and self.settings.compiler == "Visual Studio":
+        if not self.options.shared:
             for lib in range(len(self.cpp_info.libs)):
                 self.cpp_info.libs[lib] += "-static"
-            self.cpp_info.libs.append("mgl")
+
+        #    self.cpp_info.libs.append("mgl")

--- a/conanfile.py
+++ b/conanfile.py
@@ -187,5 +187,6 @@ class MathglConan(ConanFile):
         if not self.options.shared:
             for lib in range(len(self.cpp_info.libs)):
                 self.cpp_info.libs[lib] += "-static"
+            self.cpp_info.defines = ["MGL_STATIC_DEFINE"]
 
         #    self.cpp_info.libs.append("mgl")

--- a/conanfile.py
+++ b/conanfile.py
@@ -163,12 +163,11 @@ class MathglConan(ConanFile):
             cmake.install()
         self.copy("*.pdb", dst="lib")
 
-        if self.options.lgpl:
-            theLicense = 'COPYING_LGPL'
-        else:
-            theLicense = 'COPYING'
-        self.copy(theLicense, dst="licenses", src=self.source_subfolder,
+        self.copy('COPYING', dst="licenses", src=self.source_subfolder,
                   ignore_case=True, keep_path=False)
+        if self.options.lgpl:
+            self.copy('COPYING_LGPL', dst="licenses", src=self.source_subfolder,
+                      ignore_case=True, keep_path=False)
         if self.options.shared:
             pass  # The dynamic version is needed for the bin/mglconv
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,8 @@
 
 from conans import ConanFile, CMake, tools, RunEnvironment
 from conans.errors import ConanInvalidConfiguration
-
+import os
+import re
 
 class MathglConan(ConanFile):
     name = "mathgl"
@@ -23,6 +24,7 @@ class MathglConan(ConanFile):
     source_subfolder = "mathgl-{}".format(version)
     build_subfolder = "build_subfolder"
     exports_sources = "patch/*"
+    keep_imports = True
     options = {"shared": [True, False],
                "lgpl": [True, False],
                "double_precision": [True, False],
@@ -135,6 +137,9 @@ class MathglConan(ConanFile):
                 raise ConanInvalidConfiguration(
                     "pthr_widget, pthread are incompatible with Visual Studio")
 
+    def imports(self):
+        self.copy("*", dst="licenses", src="licenses", folder=True)
+
     def source(self):
         link = "https://sourceforge.net/projects/mathgl/files/mathgl/mathgl%20{0}/mathgl-{0}.tar.gz".format(self.version)
         tools.get(link, sha1="c7faa770a78a8b6783a4eab6959703172f28b329")  # sha1 is for 2.4.4
@@ -162,14 +167,25 @@ class MathglConan(ConanFile):
             cmake = self._configure_cmake()
             cmake.install()
         self.copy("*.pdb", dst="lib")
-
+        restatic = re.compile('(.*[.]a$)|(.*-static[.]lib)')
+        redll = re.compile('.*[.]dll$')
+        for root, dirs, files in os.walk(os.path.join(self.package_folder, 'lib')):
+            for file in files:
+                if (self.options.shared and restatic.match(file)) or \
+                   (not self.options.shared and not restatic.match(file)):
+                    os.remove(os.path.join(root,file))
+        if not self.options.shared and self.settings.os == "Windows":
+            for root, dirs, files in os.walk(os.path.join(self.package_folder, 'bin')):
+                for file in files:
+                    if redll.match(file):
+                        os.remove(os.path.join(root,file))
         self.copy('COPYING', dst="licenses", src=self.source_subfolder,
                   ignore_case=True, keep_path=False)
         if self.options.lgpl:
             self.copy('COPYING_LGPL', dst="licenses", src=self.source_subfolder,
                       ignore_case=True, keep_path=False)
         if self.options.shared:
-            pass  # The dynamic version is needed for the bin/mglconv
+            self.copy("*", dst="licenses", src="licenses", keep_path=True)
 
     def package_info(self):
         self.cpp_info.name = 'MathGL'
@@ -184,8 +200,8 @@ class MathglConan(ConanFile):
 
         #if not self.options.shared and self.settings.compiler == "Visual Studio":
         if not self.options.shared:
-            for lib in range(len(self.cpp_info.libs)):
-                self.cpp_info.libs[lib] += "-static"
+            if self.settings.compiler == "Visual Studio":
+                for lib in range(len(self.cpp_info.libs)):
+                    self.cpp_info.libs[lib] += "-static"
             self.cpp_info.defines = ["MGL_STATIC_DEFINE","_CRT_STDIO_ISO_WIDE_SPECIFIERS"]
 
-        #    self.cpp_info.libs.append("mgl")

--- a/conanfile.py
+++ b/conanfile.py
@@ -187,6 +187,6 @@ class MathglConan(ConanFile):
         if not self.options.shared:
             for lib in range(len(self.cpp_info.libs)):
                 self.cpp_info.libs[lib] += "-static"
-            self.cpp_info.defines = ["MGL_STATIC_DEFINE"]
+            self.cpp_info.defines = ["MGL_STATIC_DEFINE","_CRT_STDIO_ISO_WIDE_SPECIFIERS"]
 
         #    self.cpp_info.libs.append("mgl")

--- a/patch/CMakeLists.patch
+++ b/patch/CMakeLists.patch
@@ -1,5 +1,5 @@
---- CMakeLists.txt	2019-10-29 10:52:18.507507100 +0100
-+++ New_CMakeLists.txt	2019-10-29 10:51:59.303243000 +0100
+--- CMakeLists.txt	2019-07-08 20:56:57.000000000 +0200
++++ CMakeLists.txt	2020-08-01 10:55:31.435561859 +0200
 @@ -1,6 +1,19 @@
  cmake_minimum_required(VERSION 3.1.0)
  
@@ -12,7 +12,7 @@
 +find_package(PNG REQUIRED)
 +
 +set(CMAKE_CXX_STANDARD 11)
-+set(CMAKE_POSITION_INDEPENDENT_CODE:BOOL ON)
++set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 +if (APPLE)
 +    set(CMAKE_INSTALL_RPATH "@executable_path/../lib")
 +else()
@@ -30,6 +30,16 @@
  set(MathGL_VERSION_MAJOR 2)
  set(MathGL_VERSION_MINOR 4)
  set(MathGL_PATCH_VERSION 4)
+@@ -78,8 +91,8 @@
+        set_target_properties(${mgllib} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+        set_target_properties(${mgllib} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+        target_compile_definitions(${mgllib}-static PUBLIC MGL_STATIC_DEFINE)
++       set(mgl_lib_static "-static")
+        if(MSVC)
+-	   set(mgl_lib_static "-static")
+            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+                set(mgl_lib_end "d")
+ 	   else(CMAKE_BUILD_TYPE STREQUAL "Debug")
 @@ -535,16 +548,9 @@
  	if(NOT MGL_HAVE_PNG)
  		message(SEND_ERROR "You have to enable PNG if you plan to use PDF export.")

--- a/patch/CMakeLists.patch
+++ b/patch/CMakeLists.patch
@@ -30,16 +30,6 @@
  set(MathGL_VERSION_MAJOR 2)
  set(MathGL_VERSION_MINOR 4)
  set(MathGL_PATCH_VERSION 4)
-@@ -78,8 +91,8 @@
-        set_target_properties(${mgllib} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-        set_target_properties(${mgllib} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
-        target_compile_definitions(${mgllib}-static PUBLIC MGL_STATIC_DEFINE)
-+       set(mgl_lib_static "-static")
-        if(MSVC)
--	   set(mgl_lib_static "-static")
-            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-                set(mgl_lib_end "d")
- 	   else(CMAKE_BUILD_TYPE STREQUAL "Debug")
 @@ -535,16 +548,9 @@
  	if(NOT MGL_HAVE_PNG)
  		message(SEND_ERROR "You have to enable PNG if you plan to use PDF export.")

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -5,6 +5,14 @@ include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
 find_package(MathGL MODULE REQUIRED)
 
 option(WITH_QT "MathGL with qt5 enabled" OFF)
+option(WITH_OPENGL "MathGL is opengl enabled" ON)
+
+if(WITH_OPENGL)
+  set(OpenGL_GL_PREFERENCE_LEGACY)
+  find_package(OPENGL REQUIRED)
+  message(STATUS "OPENGL_FOUND=${OPENGL_FOUND}")
+  message(STATIS "OPENGL_LIBRARIES=${OPENGL_LIBRARIES}")
+endif()
 
 if(WITH_QT)
   find_package(Qt5 COMPONENTS Widgets REQUIRED)
@@ -15,4 +23,4 @@ if(WITH_QT)
 endif()
 
 add_executable(example example.cpp)
-target_link_libraries(example MathGL::MathGL ${WITH_QT_TARGET})
+target_link_libraries(example MathGL::MathGL ${WITH_QT_TARGET} ${OPENGL_LIBRARIES})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -12,7 +12,7 @@ class MathglTestConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_QT"] = self.options["mathgl"].qt5
-        cmake.definitions["WITH_OPENGL"] = self.options["mathgl"].opengl and not self.options["mathgl"].shared
+        cmake.definitions["WITH_OPENGL"] = self.options["mathgl"].opengl and not self.options["mathgl"].shared and self.settings.os = "Windows"
         cmake.configure()
         cmake.build()
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -12,6 +12,7 @@ class MathglTestConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_QT"] = self.options["mathgl"].qt5
+        cmake.definitions["WITH_OPENGL"] = self.options["mathgl"].opengl and not self.options["mathgl"].shared
         cmake.configure()
         cmake.build()
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -12,7 +12,7 @@ class MathglTestConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_QT"] = self.options["mathgl"].qt5
-        cmake.definitions["WITH_OPENGL"] = self.options["mathgl"].opengl and not self.options["mathgl"].shared and self.settings.os = "Windows"
+        cmake.definitions["WITH_OPENGL"] = self.options["mathgl"].opengl and not self.options["mathgl"].shared and self.settings.os == "Windows"
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
- This package now includes either the shared or static library target (both are compiled, but one will be deleted before packaging)
- License files for dependencies are bundled with the package if the shared library is built
- The cmake config scripts made by the original build files are unusable, they are now deleted to avoid confusion

I still don't expect that this package can be build flawlessly for all combinations of options...